### PR TITLE
File path prefix unique

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,13 +102,13 @@ connect-backup use a directory/prefix (see what I did there?) structure so every
 is not there it will create it on the fly:
 ```
 your-connect-backup-workspace
-   ├──common
-   ├──flows
-   ├──flows-raw
-   ├──routing-profiles
-   ├──users
-   └──user-hierarchy-groups
-
+   └──your-connect-instance-id
+       ├──common
+       ├──flows
+       ├──flows-raw
+       ├──routing-profiles
+       ├──users
+       └──user-hierarchy-groups
 ````
 
 If you wish to only backup or export a single contact flow, pass `--flow-name` to the backup comand.

--- a/connect-backup.go
+++ b/connect-backup.go
@@ -229,7 +229,7 @@ func (cb ConnectBackup) backupPrompts() error {
 		InstanceId: cb.ConnectInstance.Id,
 	})
 
-	_ = cb.TheWriter.writeList(*cb.ConnectInstance.Id, result.PromptSummaryList)
+	_ = cb.TheWriter.writeList(string(Prompts)+"s", result.PromptSummaryList)
 	return err
 
 }

--- a/lambda/template.yaml
+++ b/lambda/template.yaml
@@ -39,7 +39,7 @@ Resources:
         Targets:
           - Arn: !GetAtt ConnectBackupLambda.Arn
             Id: "AWS_Connect__Backup_Lambda"
-            Input: !Sub '{"ConnectInstanceId" : "${connectInstanceId}", "S3DestUrl" : "s3://${s3Bucket}/${connectInstanceId}","FlowsRaw": true}'
+            Input: !Sub '{"ConnectInstanceId" : "${connectInstanceId}", "S3DestUrl" : "s3://${s3Bucket}","FlowsRaw": true}'
   permissionForEventsToInvokeLambda:
     Type: AWS::Lambda::Permission
     Properties:

--- a/restore.go
+++ b/restore.go
@@ -27,14 +27,14 @@ import (
 type ConnectElement string
 
 const (
-	Flows                  ConnectElement = "flow"
+	Flows                  ConnectElement = "flows"
 	FlowsRaw               ConnectElement = "flows-raw"
-	RoutingProfiles        ConnectElement = "routing-profile"
-	RoutingProfileQueues   ConnectElement = "routing-profile-queue"
-	Users                  ConnectElement = "user"
-	UserHierarchyGroups    ConnectElement = "user-hierarchy-group"
-	UserHierarchyStructure ConnectElement = "user-hierarchy-structure"
-	Prompts                ConnectElement = "prompt"
+	RoutingProfiles        ConnectElement = "routing-profiles"
+	RoutingProfileQueues   ConnectElement = "routing-profile-queues"
+	Users                  ConnectElement = "users"
+	UserHierarchyGroups    ConnectElement = "user-hierarchy-groups"
+	UserHierarchyStructure ConnectElement = "user-hierarchy-structures"
+	Prompts                ConnectElement = "prompts"
 )
 
 type sourceType int

--- a/writers.go
+++ b/writers.go
@@ -87,16 +87,16 @@ func prettyJSON(flow string) (bytes.Buffer, error) {
 	return prettyJSON, err
 }
 
-func (fw *FileWriter) InitDirs() {
+func (fw *FileWriter) InitDirs(instanceId string) {
 	//ensure the needed child dirs are present
-	os.Mkdir(fw.Path+pathSeparator+string(Flows)+"s", 0744)
-	os.Mkdir(fw.Path+pathSeparator+string(FlowsRaw), 0744)
-	os.Mkdir(fw.Path+pathSeparator+string(RoutingProfiles)+"s", 0744)
-	os.Mkdir(fw.Path+pathSeparator+string(RoutingProfileQueues)+"s", 0744)
-	os.Mkdir(fw.Path+pathSeparator+string(Users)+"s", 0744)
-	os.Mkdir(fw.Path+pathSeparator+string(UserHierarchyGroups)+"s", 0744)
-	os.Mkdir(fw.Path+pathSeparator+string(Prompts)+"s", 0744)
-	os.Mkdir(fw.Path+pathSeparator+common, 0744)
+	os.MkdirAll(fw.Path+pathSeparator+string(Flows)+"s", 0744)
+	os.MkdirAll(fw.Path+pathSeparator+string(FlowsRaw), 0744)
+	os.MkdirAll(fw.Path+pathSeparator+string(RoutingProfiles)+"s", 0744)
+	os.MkdirAll(fw.Path+pathSeparator+string(RoutingProfileQueues)+"s", 0744)
+	os.MkdirAll(fw.Path+pathSeparator+string(Users)+"s", 0744)
+	os.MkdirAll(fw.Path+pathSeparator+string(UserHierarchyGroups)+"s", 0744)
+	os.MkdirAll(fw.Path+pathSeparator+string(Prompts)+"s", 0744)
+	os.MkdirAll(fw.Path+pathSeparator+common, 0744)
 
 }
 

--- a/writers.go
+++ b/writers.go
@@ -49,15 +49,15 @@ func buildPrefix(result interface{}) (string, error) {
 
 	switch result.(type) {
 	case connect.ContactFlow:
-		objectPrefix = string(Flows) + "s/" + *result.(connect.ContactFlow).Name + jsonExtn
+		objectPrefix = string(Flows) + "/" + *result.(connect.ContactFlow).Name + jsonExtn
 	case connect.RoutingProfile:
-		objectPrefix = string(RoutingProfiles) + "s/" + *result.(connect.RoutingProfile).Name + jsonExtn
+		objectPrefix = string(RoutingProfiles) + "/" + *result.(connect.RoutingProfile).Name + jsonExtn
 	case backupRoutingProfileQueueSummary:
-		objectPrefix = string(RoutingProfileQueues) + "s/" + result.(backupRoutingProfileQueueSummary).routingProfile + jsonExtn
+		objectPrefix = string(RoutingProfileQueues) + "/" + result.(backupRoutingProfileQueueSummary).routingProfile + jsonExtn
 	case connect.User:
-		objectPrefix = string(Users) + "s/" + *result.(connect.User).Username + jsonExtn
+		objectPrefix = string(Users) + "/" + *result.(connect.User).Username + jsonExtn
 	case connect.HierarchyGroup:
-		objectPrefix = string(UserHierarchyGroups) + "s/" + *result.(connect.HierarchyGroup).Name + jsonExtn
+		objectPrefix = string(UserHierarchyGroups) + "/" + *result.(connect.HierarchyGroup).Name + jsonExtn
 	case connect.HierarchyStructure:
 		objectPrefix = common + "/" + string(UserHierarchyStructure) + jsonExtn
 	default:
@@ -72,9 +72,9 @@ func buildPrefixList(name string, result interface{}) (string, error) {
 
 	switch result.(type) {
 	case []*connect.RoutingProfileQueueConfigSummary:
-		objectPrefix = string(RoutingProfileQueues) + "s/" + name + jsonExtn
+		objectPrefix = string(RoutingProfileQueues) + "/" + name + jsonExtn
 	case []*connect.PromptSummary:
-		objectPrefix = string(Prompts) + "s/" + name + jsonExtn
+		objectPrefix = string(Prompts) + "/" + name + jsonExtn
 	default:
 		return "", errors.New("unexpected type passed to writer")
 	}
@@ -89,13 +89,13 @@ func prettyJSON(flow string) (bytes.Buffer, error) {
 
 func (fw *FileWriter) InitDirs(instanceId string) {
 	//ensure the needed child dirs are present
-	os.MkdirAll(fw.Path+pathSeparator+string(Flows)+"s", 0744)
+	os.MkdirAll(fw.Path+pathSeparator+string(Flows), 0744)
 	os.MkdirAll(fw.Path+pathSeparator+string(FlowsRaw), 0744)
-	os.MkdirAll(fw.Path+pathSeparator+string(RoutingProfiles)+"s", 0744)
-	os.MkdirAll(fw.Path+pathSeparator+string(RoutingProfileQueues)+"s", 0744)
-	os.MkdirAll(fw.Path+pathSeparator+string(Users)+"s", 0744)
-	os.MkdirAll(fw.Path+pathSeparator+string(UserHierarchyGroups)+"s", 0744)
-	os.MkdirAll(fw.Path+pathSeparator+string(Prompts)+"s", 0744)
+	os.MkdirAll(fw.Path+pathSeparator+string(RoutingProfiles), 0744)
+	os.MkdirAll(fw.Path+pathSeparator+string(RoutingProfileQueues), 0744)
+	os.MkdirAll(fw.Path+pathSeparator+string(Users), 0744)
+	os.MkdirAll(fw.Path+pathSeparator+string(UserHierarchyGroups), 0744)
+	os.MkdirAll(fw.Path+pathSeparator+string(Prompts), 0744)
 	os.MkdirAll(fw.Path+pathSeparator+common, 0744)
 
 }


### PR DESCRIPTION
backups will always include the instance id as a prefix.  this is prep work for the tool to work backuping up and restoring to multiple instances.  It's probably helps tidyup backups anyway