### PR TITLE
Fix bug in Lambda after new prefix functionality required.  Describe …

### DIFF
--- a/lambda/connect-backup-lambda.go
+++ b/lambda/connect-backup-lambda.go
@@ -75,11 +75,17 @@ func HandleRequest(ctx context.Context, backupRequest Request) (Response, error)
 	}
 	log.Println("FlowsRaw : " + strconv.FormatBool(flowsRaw))
 
-	cb := connect_backup.ConnectBackup{ConnectInstanceId: &instanceId,
+	connectSvc := connect.New(sess)
+	result, err := connectSvc.DescribeInstance(&connect.DescribeInstanceInput{
+		InstanceId: &instanceId,
+	})
+
+	cb := connect_backup.ConnectBackup{ConnectInstance: *result.Instance,
 		Svc:       svc,
 		TheWriter: &connect_backup.S3Writer{Destination: *s3Url, Sess: sess},
 		RawFlow:   flowsRaw,
 	}
+
 	err = cb.Backup()
 
 	if err != nil {

--- a/lambda/template.yaml
+++ b/lambda/template.yaml
@@ -77,6 +77,7 @@ Resources:
                 - connect:ListUserHierarchyGroups
                 - connect:ListUsers
                 - connect:DescribeUserHierarchyStructure
+                - connect:DescribeInstance
               Resource: !Sub "arn:aws:connect:${AWS::Region}:${AWS::AccountId}:instance/${connectInstanceId}"
             - Effect: Allow
               Action:


### PR DESCRIPTION
Instance is now called at the start of processing to get instance information.

Since this is for the lambda example code only, no new version id created for this change.